### PR TITLE
Don't throw when commitId is null

### DIFF
--- a/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
+++ b/src/main/java/com/flowdock/jenkins/TeamInboxMessage.java
@@ -93,12 +93,14 @@ public class TeamInboxMessage extends FlowdockMessage {
         if(commits != null) {
             content.append("<h3>Changes</h3><div class=\"commits\"><ul class=\"commit-list clean\">");
             for(Entry commit : commits) {
+                String commitId = commit.getCommitId();
+                commitId = commitId == null ? "unknown" : commitId;
                 content.append("<li class=\"commit\"><span class=\"commit-details\">");
                 content.append("<span class=\"author-info\">").
                     append("<span>").append(commit.getAuthor()).append("</span>").
                 append("</span> &nbsp;");
-                content.append("<span title=\"" + commit.getCommitId() + "\" class=\"commit-sha\">").
-                    append(commit.getCommitId().substring(0, 7)).
+                content.append("<span title=\"" + commitId + "\" class=\"commit-sha\">").
+                    append(commitId.substring(0, 7)).
                 append("</span> &nbsp;");
                 content.append("<span class=\"commit-message\">").append(commit.getMsg()).append("</span>");
                 content.append("</span></li>");


### PR DESCRIPTION
Last week, we added the Flowdock-Jenkins plugin to our Jenkins installation. The first time the project ran, the build showed as failed. The reason was because the plugin threw a null reference exception because the commitId was null. Honestly, I don't know why it was null and didn't care much; I just didn't want it to throw. I compiled this new code, added it to our Jenkins, and everything worked great. I'd like it to be brought into the main project so I can continue to use your official plugin in Jenkins.
